### PR TITLE
fix compiler warning - remove unused variable

### DIFF
--- a/Classes/YISplashScreen.m
+++ b/Classes/YISplashScreen.m
@@ -205,7 +205,6 @@ static CALayer* __copiedRootLayer = nil;
     
     // create rootView snapshot
     UIGraphicsBeginImageContextWithOptions(mainRootView.bounds.size, NO, 0);
-    CGContextRef context = UIGraphicsGetCurrentContext();
     
     if ([mainRootView respondsToSelector:@selector(drawViewHierarchyInRect:afterScreenUpdates:)]) {
 #if defined(__IPHONE_7_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_7_0


### PR DESCRIPTION
Cocoapods now expose all warning from Pods, and we can only disable all warnings, not one by one. So it's very much helpful have no warning in Pods. Thank you!
