### PR TITLE
make demo project working without cocoapods

### DIFF
--- a/Demo/Podfile
+++ b/Demo/Podfile
@@ -1,3 +1,0 @@
-platform :ios, '5.0'
-
-pod 'YISplashScreen', :path => '../'

--- a/Demo/YISplashScreenDemo.xcodeproj/project.pbxproj
+++ b/Demo/YISplashScreenDemo.xcodeproj/project.pbxproj
@@ -26,7 +26,9 @@
 		48924A3615898E760085703E /* second.png in Resources */ = {isa = PBXBuildFile; fileRef = 48924A3515898E760085703E /* second.png */; };
 		48924A3815898E760085703E /* second@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 48924A3715898E760085703E /* second@2x.png */; };
 		48924A661589D53F0085703E /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48924A651589D53F0085703E /* QuartzCore.framework */; };
-		A29AD7BA38024E5EB56B8253 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 54306ED2A0C44E1A8F8AFA9B /* libPods.a */; };
+		4B7463D9189A572E0048C528 /* YISplashScreen+Migration.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B7463D4189A572E0048C528 /* YISplashScreen+Migration.m */; };
+		4B7463DA189A572E0048C528 /* YISplashScreen.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B7463D6189A572E0048C528 /* YISplashScreen.m */; };
+		4B7463DB189A572E0048C528 /* YISplashScreenAnimation.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B7463D8189A572E0048C528 /* YISplashScreenAnimation.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -55,8 +57,13 @@
 		48924A3515898E760085703E /* second.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = second.png; sourceTree = "<group>"; };
 		48924A3715898E760085703E /* second@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "second@2x.png"; sourceTree = "<group>"; };
 		48924A651589D53F0085703E /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		4B7463D3189A572E0048C528 /* YISplashScreen+Migration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "YISplashScreen+Migration.h"; sourceTree = "<group>"; };
+		4B7463D4189A572E0048C528 /* YISplashScreen+Migration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "YISplashScreen+Migration.m"; sourceTree = "<group>"; };
+		4B7463D5189A572E0048C528 /* YISplashScreen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YISplashScreen.h; sourceTree = "<group>"; };
+		4B7463D6189A572E0048C528 /* YISplashScreen.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YISplashScreen.m; sourceTree = "<group>"; };
+		4B7463D7189A572E0048C528 /* YISplashScreenAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YISplashScreenAnimation.h; sourceTree = "<group>"; };
+		4B7463D8189A572E0048C528 /* YISplashScreenAnimation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YISplashScreenAnimation.m; sourceTree = "<group>"; };
 		54306ED2A0C44E1A8F8AFA9B /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		BE80D0AB499E46F182ED0A03 /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -68,7 +75,6 @@
 				48924A1415898E760085703E /* UIKit.framework in Frameworks */,
 				48924A1615898E760085703E /* Foundation.framework in Frameworks */,
 				48924A1815898E760085703E /* CoreGraphics.framework in Frameworks */,
-				A29AD7BA38024E5EB56B8253 /* libPods.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -78,10 +84,10 @@
 		48924A0415898E760085703E = {
 			isa = PBXGroup;
 			children = (
+				4B7463D2189A572E0048C528 /* Classes */,
 				48924A1915898E760085703E /* YISplashScreenDemo */,
 				48924A1215898E760085703E /* Frameworks */,
 				48924A1015898E760085703E /* Products */,
-				BE80D0AB499E46F182ED0A03 /* Pods.xcconfig */,
 			);
 			sourceTree = "<group>";
 		};
@@ -140,6 +146,20 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		4B7463D2189A572E0048C528 /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				4B7463D3189A572E0048C528 /* YISplashScreen+Migration.h */,
+				4B7463D4189A572E0048C528 /* YISplashScreen+Migration.m */,
+				4B7463D5189A572E0048C528 /* YISplashScreen.h */,
+				4B7463D6189A572E0048C528 /* YISplashScreen.m */,
+				4B7463D7189A572E0048C528 /* YISplashScreenAnimation.h */,
+				4B7463D8189A572E0048C528 /* YISplashScreenAnimation.m */,
+			);
+			name = Classes;
+			path = ../Classes;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -147,11 +167,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 48924A3B15898E760085703E /* Build configuration list for PBXNativeTarget "YISplashScreenDemo" */;
 			buildPhases = (
-				68A22376B05749DBA4106929 /* Check Pods Manifest.lock */,
 				48924A0B15898E760085703E /* Sources */,
 				48924A0C15898E760085703E /* Frameworks */,
 				48924A0D15898E760085703E /* Resources */,
-				72CA0DB76A1F42C89FE7CE53 /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -209,43 +227,15 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
-/* Begin PBXShellScriptBuildPhase section */
-		68A22376B05749DBA4106929 /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sanbox is not in sync with the Podfile.lock. Run 'pod install'.\nEOM\n    exit 1\nfi\n";
-		};
-		72CA0DB76A1F42C89FE7CE53 /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-resources.sh\"\n";
-		};
-/* End PBXShellScriptBuildPhase section */
-
 /* Begin PBXSourcesBuildPhase section */
 		48924A0B15898E760085703E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4B7463D9189A572E0048C528 /* YISplashScreen+Migration.m in Sources */,
+				4B7463DB189A572E0048C528 /* YISplashScreenAnimation.m in Sources */,
 				48924A2015898E760085703E /* main.m in Sources */,
+				4B7463DA189A572E0048C528 /* YISplashScreen.m in Sources */,
 				48924A2415898E760085703E /* AppDelegate.m in Sources */,
 				48924A2D15898E760085703E /* FirstViewController.m in Sources */,
 				48924A3415898E760085703E /* SecondViewController.m in Sources */,
@@ -331,7 +321,6 @@
 		};
 		48924A3C15898E760085703E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BE80D0AB499E46F182ED0A03 /* Pods.xcconfig */;
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "YISplashScreenDemo/YISplashScreenDemo-Prefix.pch";
@@ -344,7 +333,6 @@
 		};
 		48924A3D15898E760085703E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BE80D0AB499E46F182ED0A03 /* Pods.xcconfig */;
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "YISplashScreenDemo/YISplashScreenDemo-Prefix.pch";


### PR DESCRIPTION
Thank you for the YISplashScreen!

This change is to allow double click Xcode project and select Run to see the demo.
Allows people who do not have the right version of cocoapods installed to preview the demo.
Changes in pod classes will be immediately reflected in demo for experiments.
